### PR TITLE
Miscellaneous improvements and code refactor

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,13 @@
+name: Linter Scans
+
+on: [push]
+
+jobs:
+  shellcheck-scan:
+    name: ShellCheck Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Run ShellCheck
+        run: shellcheck *.sh

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -72,14 +72,10 @@ software_summary ()
 
 hardware_info ()
 {
-    if [ "$USE_DEVICETREE" ]; then
-        hw_model=$(tr -d '\0' </proc/device-tree/model)
-        serial=$(tr -d '\0' </proc/device-tree/serial-number)
-        if [ -f /proc/device-tree/toradex,product-id ]; then
-            som_pid4=$(tr -d '\0' </proc/device-tree/toradex,product-id)
-            som_pid8=$(tr -d '\0' </proc/device-tree/toradex,board-rev)
-        fi
-    fi
+    hw_model=$(tr -d '\0' 2> /dev/null </proc/device-tree/model)
+    serial=$(tr -d '\0' 2> /dev/null </proc/device-tree/serial-number)
+    som_pid4=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,product-id)
+    som_pid8=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,board-rev)
     processor=$(uname -m)
 
     print_header "Hardware info"
@@ -94,16 +90,14 @@ bootloader_info ()
 {
     print_header "Bootloader info"
     if [ "$BOOTLOADER" = "U-Boot" ]; then
-        uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
-        if [ "$(which fw_printenv)" ]; then
-            uboot_env_vendor=$(fw_printenv vendor | sed -r "s/.*=//g")
-            uboot_env_board=$(fw_printenv board | sed -r "s/.*=//g")
-            uboot_env_fdt_board=$(fw_printenv fdt_board | sed -r "s/.*=//g")
-            uboot_env_soc=$(fw_printenv soc | sed -r "s/.*=//g")
-            uboot_env_vidargs=$(fw_printenv vidargs | sed -r "s/.*=//g")
-            uboot_env_sec_boot=$(fw_printenv sec_boot | sed -r "s/.*=//g")
-            uboot_env_bootdelay=$(fw_printenv bootdelay | sed -r "s/.*=//g")
-        fi
+        uboot_version=$(tr -d '\0' 2> /dev/null </proc/device-tree/chosen/u-boot,version)
+        uboot_env_vendor=$(fw_printenv vendor 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_board=$(fw_printenv board 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_fdt_board=$(fw_printenv fdt_board 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_soc=$(fw_printenv soc 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_vidargs=$(fw_printenv vidargs 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_sec_boot=$(fw_printenv sec_boot 2> /dev/null | sed -r "s/.*=//g")
+        uboot_env_bootdelay=$(fw_printenv bootdelay 2> /dev/null | sed -r "s/.*=//g")
 
         print_info "U-Boot version" "$uboot_version"
         print_info "U-Boot vendor" "$uboot_env_vendor"
@@ -129,31 +123,19 @@ device_tree_info ()
         return
     fi
 
-    dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
-    if [ "$(which fw_printenv)" ]; then
-        dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
-    fi
+    dt_compatible=$(tr -d '\0' 2> /dev/null </proc/device-tree/compatible)
+    dt_used=$(fw_printenv fdtfile 2> /dev/null | sed -r "s/.*=//g")
     if [ -d /boot/ostree ]; then
         stateroot=$(awk -F "ostree=" '{print $2}' /proc/cmdline | awk '{print $1}' | awk -F "/" '{print $5}')
         # shellcheck disable=SC2010
-        dt_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/ | grep dtb)
-        if [ -f /boot/ostree/torizon-"$stateroot"/dtb/overlays.txt ]; then
-            dto_enabled=$(cat /boot/ostree/torizon-"$stateroot"/dtb/overlays.txt)
-            dto_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/overlays)
-        else
-            dto_enabled=""
-            dto_available=""
-        fi
+        dt_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/ 2> /dev/null | grep dtb)
+        dto_enabled=$(cat /boot/ostree/torizon-"$stateroot"/dtb/overlays.txt 2> /dev/null)
+        dto_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/overlays 2> /dev/null)
     else
         # shellcheck disable=SC2010
-        dt_available=$(ls /boot/ | grep dtb)
-        if [ -f /boot/overlays.txt ]; then
-            dto_enabled=$(cat /boot/overlays.txt)
-            dto_available=$(ls /boot/overlays)
-        else
-            dto_enabled=""
-            dto_available=""
-        fi
+        dt_available=$(ls /boot/ 2> /dev/null | grep dtb)
+        dto_enabled=$(cat /boot/overlays.txt 2> /dev/null)
+        dto_available=$(ls /boot/overlays 2> /dev/null)
     fi
 
     print_header "Device tree"

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -72,16 +72,20 @@ software_summary ()
 
 hardware_info ()
 {
-    som_model=$(tr -d '\0' </proc/device-tree/model)
-    som_pid4=$(tr -d '\0' </proc/device-tree/toradex,product-id)
-    som_pid8=$(tr -d '\0' </proc/device-tree/toradex,board-rev)
-    serial=$(tr -d '\0' </proc/device-tree/serial-number)
+    if [ "$USE_DEVICETREE" ]; then
+        hw_model=$(tr -d '\0' </proc/device-tree/model)
+        serial=$(tr -d '\0' </proc/device-tree/serial-number)
+        if [ -f /proc/device-tree/toradex,product-id ]; then
+            som_pid4=$(tr -d '\0' </proc/device-tree/toradex,product-id)
+            som_pid8=$(tr -d '\0' </proc/device-tree/toradex,board-rev)
+        fi
+    fi
     processor=$(uname -m)
 
     print_header "Hardware info"
-    print_info "SoM model" "$som_model"
-    print_info "SoM version" "$som_pid4 $som_pid8"
-    print_info "SoM serial number" "$serial"
+    print_info "HW model" "$hw_model"
+    print_info "Toradex version" "$som_pid4 $som_pid8"
+    print_info "Serial number" "$serial"
     print_info "Processor arch" "$processor"
     print_footer
 }

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -96,8 +96,8 @@ device_tree_info()
     echo "-----------------"
 
     echo ""
-    echo "-----------------"
     echo "Device tree overlays"
+    echo "-----------------"
     echo "Overlays enabled:[$dto_enabled]"
     echo "Overlays available:[$dto_available]"
     echo "-----------------"

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -183,6 +183,19 @@ distro_detect ()
     fi
 }
 
+bootloader_detect ()
+{
+    if [ -f /boot/grub/grub.cfg ] || [ "$(command -v grub-install)" ]; then
+        export BOOTLOADER="GRUB"
+    # fw_utils - thus fw_printenv - are not present on L4T
+    elif find /boot/ -name "*dtb" | grep -q . || [ "$(command -v fw_printenv)" ]; then
+        export BOOTLOADER="U-Boot"
+    # Don't care about other bootloaders for now, only GRUB and U-Boot
+    else
+        export BOOTLOADER="Unknown"
+    fi
+}
+
 help_info ()
 {
     echo "Usage: tdx_version.sh [OPTION]"
@@ -202,6 +215,7 @@ help_info ()
 
 check_root_user
 distro_detect
+bootloader_detect
 
 case $1 in
     "--help" | "-h")

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -4,6 +4,45 @@
 # Date: may-02-2022
 # Author: hiagofranco & g-claudino
 
+HORIZONTAL_LINE_WIDTH=60
+TABULATION_WIDTH=25
+
+print_header ()
+{
+    if [ -n "$1" ]; then
+        echo ""
+        echo "$1"
+        printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
+        printf "\n"
+    else
+        echo 'Error: "print_header" called without a parameter!'
+        exit 1
+    fi
+}
+
+print_info ()
+{
+    if [ -z "$1" ] ; then
+        echo 'Error: "print_info" is missing parameter(s)!'
+        exit 1
+    else
+        if [ -z "$2" ]; then
+            printf "%-${TABULATION_WIDTH}s %s\n" "$1:" "-"
+        elif [ "$(echo "$2" | sed -re '/^$/d' | wc -l)" -gt 1 ]; then
+            echo "$1:"
+            echo "$2" | sed "s/^/ $(printf "%0.s " $(seq 1 $TABULATION_WIDTH))/"
+        else
+            printf "%-${TABULATION_WIDTH}s %s\n" "$1:" "$2"
+        fi
+    fi
+}
+
+print_footer ()
+{
+    printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
+    printf "\n"
+}
+
 software_info ()
 {
     uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
@@ -22,20 +61,18 @@ software_info ()
     fi
     hostname=$(cat /etc/hostname)
 
-    echo ""
-    echo "Software info"
-    echo "-----------------"
-    echo "U-Boot-version:[$uboot_version]"
-    echo "U-Boot vendor:[$uboot_env_vendor]"
-    echo "U-Boot video args:[$uboot_env_vidargs]"
-    echo "U-Boot secure boot:[$uboot_env_sec_boot]"
-    echo "U-Boot boot delay:[$uboot_env_bootdelay]"
-    echo "Kernel version:[$kernel_version]"
-    echo "Kernel command line:[$kernel_cmdline]"
-    echo "Distro name:[$distro_name]"
-    echo "Distro version:[$distro_version]"
-    echo "Hostname:[$hostname]"
-    echo "-----------------"
+    print_header "Software info"
+    print_info "U-Boot-version" "$uboot_version"
+    print_info "U-Boot vendor" "$uboot_env_vendor"
+    print_info "U-Boot video args" "$uboot_env_vidargs"
+    print_info "U-Boot secure boot" "$uboot_env_sec_boot"
+    print_info "U-Boot boot delay" "$uboot_env_bootdelay"
+    print_info "Kernel version" "$kernel_version"
+    print_info "Kernel command line" "$kernel_cmdline"
+    print_info "Distro name" "$distro_name"
+    print_info "Distro version" "$distro_version"
+    print_info "Hostname" "$hostname"
+    print_footer
 }
 
 hardware_info ()
@@ -49,17 +86,15 @@ hardware_info ()
     uboot_env_fdt_board=$(fw_printenv fdt_board | sed -r "s/.*=//g")
     uboot_env_soc=$(fw_printenv soc | sed -r "s/.*=//g")
 
-    echo ""
-    echo "Hardware info"
-    echo "-----------------"
-    echo "SoM model:[$som_model]"
-    echo "SoM version:[$som_pid4 $som_pid8]"
-    echo "SoM serial number:[$serial]"
-    echo "Processor arch:[$processor]"
-    echo "U-Boot board:[$uboot_env_board]"
-    echo "U-Boot fdt_board:[$uboot_env_fdt_board]"
-    echo "U-Boot soc:[$uboot_env_soc]"
-    echo "-----------------"
+    print_header "Hardware info"
+    print_info "SoM model" "$som_model"
+    print_info "SoM version" "$som_pid4 $som_pid8"
+    print_info "SoM serial number" "$serial"
+    print_info "Processor arch" "$processor"
+    print_info "U-Boot board" "$uboot_env_board"
+    print_info "U-Boot fdt_board" "$uboot_env_fdt_board"
+    print_info "U-Boot soc" "$uboot_env_soc"
+    print_footer
 }
 
 device_tree_info()
@@ -89,42 +124,34 @@ device_tree_info()
         fi
     fi
 
-    echo ""
-    echo "Device tree"
-    echo "-----------------"
-    echo "Device tree enabled:[$dt_used]"
-    echo "Compatible string:[$dt_compatible]"
-    echo "Device trees available:[$dt_available]"
-    echo "-----------------"
+    print_header "Device tree"
+    print_info "Device tree enabled" "$dt_used"
+    print_info "Compatible string" "$dt_compatible"
+    print_info "Device trees available" "$dt_available"
+    print_footer
 
-    echo ""
-    echo "Device tree overlays"
-    echo "-----------------"
-    echo "Overlays enabled:[$dto_enabled]"
-    echo "Overlays available:[$dto_available]"
-    echo "-----------------"
+    print_header "Device tree overlays"
+    print_info "Overlays enabled" "$dto_enabled"
+    print_info "Overlays available" "$dto_available"
+    print_footer
 }
 
 devices_info ()
 {
     devices=$(ls -lh /dev)
 
-    echo ""
-    echo "Devices"
-    echo "-----------------"
-    echo "All devices available:[$devices]"
-    echo "-----------------"
+    print_header "Devices"
+    print_info "All devices available" "$devices"
+    print_footer
 }
 
 modules_info ()
 {
     lsmod=$(lsmod)
 
-    echo ""
-    echo "Kernel modules"
-    echo "-----------------"
-    echo "Kernel modules loaded:[$lsmod]"
-    echo "-----------------"
+    print_header "Kernel modules"
+    print_info "Kernel modules loaded" "$lsmod"
+    print_footer
 }
 
 dmesg_log ()

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -126,7 +126,9 @@ device_tree_info ()
     fi
 
     dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
-    dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
+    if [ "$(which fw_printenv)" ]; then
+        dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
+    fi
     if [ -d /boot/ostree ]; then
         stateroot=$(awk -F "ostree=" '{print $2}' /proc/cmdline | awk '{print $1}' | awk -F "/" '{print $5}')
         # shellcheck disable=SC2010

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -138,7 +138,7 @@ distro_detect ()
     if [[ -f /etc/os-release ]]; then
         export "DISTRO_$(cat /etc/os-release | grep ^NAME)"
     else
-        DISTRO_NAME="BSP"
+        DISTRO_NAME="Unknown"
     fi
 }
 

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -33,6 +33,7 @@ software_info ()
         distro_name=$(cat /etc/issue)
         distro_version=""
     fi
+    hostname=$(cat /etc/hostname)
 
     echo ""
     echo "Software info"
@@ -46,6 +47,7 @@ software_info ()
     echo "Kernel command line:[$kernel_cmdline]"
     echo "Distro name:[$distro_name]"
     echo "Distro version:[$distro_version]"
+    echo "Hostname:[$hostname]"
     echo "-----------------"
 }
 
@@ -54,6 +56,7 @@ hardware_info ()
     som_model=$(tr -d '\0' </proc/device-tree/model)
     som_pid4=$(tr -d '\0' </proc/device-tree/toradex,product-id)
     som_pid8=$(tr -d '\0' </proc/device-tree/toradex,board-rev)
+    serial=$(tr -d '\0' </proc/device-tree/serial-number)
     processor=$(uname -m)
     uboot_env_board=$(fw_printenv board | sed -r "s/.*=//g")
     uboot_env_fdt_board=$(fw_printenv fdt_board | sed -r "s/.*=//g")
@@ -64,6 +67,7 @@ hardware_info ()
     echo "-----------------"
     echo "SoM model:[$som_model]"
     echo "SoM version:[$som_pid4 $som_pid8]"
+    echo "SoM serial number:[$serial]"
     echo "Processor arch:[$processor]"
     echo "U-Boot board:[$uboot_env_board]"
     echo "U-Boot fdt_board:[$uboot_env_fdt_board]"

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -4,8 +4,12 @@
 # Date: may-02-2022
 # Author: hiagofranco & g-claudino
 
+#### Variables ####
+
 HORIZONTAL_LINE_WIDTH=60
 TABULATION_WIDTH=25
+
+#### Functions ####
 
 print_header ()
 {
@@ -186,7 +190,7 @@ help_info ()
     echo ""
 }
 
-# Main
+#### Main ####
 
 if [ "$(id -u)" != "0" ]; then
     echo "Please, run as root."

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -69,12 +69,22 @@ device_tree_info()
     if [[ -d /boot/ostree ]]; then
         stateroot=$(cat /proc/cmdline | awk -F "ostree=" '{print $2}' | awk '{print $1}' | awk -F "/" '{print $5}')
         dt_available=$(ls /boot/ostree/torizon-$stateroot/dtb/ | grep dtb)
-        dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
-        dto_available=$(ls /boot/ostree/torizon-$stateroot/dtb/overlays)
+        if [[ -f /boot/ostree/torizon-$stateroot/dtb/overlays.txt ]]; then
+            dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
+            dto_available=$(ls /boot/ostree/torizon-$stateroot/dtb/overlays)
+        else
+            dto_enabled=""
+            dto_available=""
+        fi
     else
         dt_available=$(ls /boot/ | grep dtb)
-        dto_enabled=$(cat /boot/overlays.txt)
-        dto_available=$(ls /boot/overlays)
+        if [[ -f /boot/overlays.txt ]]; then
+            dto_enabled=$(cat /boot/overlays.txt)
+            dto_available=$(ls /boot/overlays)
+        else
+            dto_enabled=""
+            dto_available=""
+        fi
     fi
 
     echo ""

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -216,7 +216,8 @@ devicetree_detect ()
     # fw_utils are not present on L4T
     # fw_utils presennce does not guarantee U-Boot is used
     # GRUB seem to have some sort of support for device tree
-    if find /boot/ -name "*dtb" | grep -q . ; then
+    if  find /boot/ -name "*dtb" 2> /dev/null | grep -q . || \
+        find /var/rootdirs/mnt/boot/ -name "*dtb" 2> /dev/null | grep -q .; then
         export USE_DEVICETREE=1
     else
         export USE_DEVICETREE=""

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -116,6 +116,7 @@ dmesg_log ()
 {
     if [[ $ref_distro =~ $ref_name ]]; then
         echo "$(dmesg)" > /home/torizon/dmesg.txt
+        chown torizon:torizon /home/torizon/dmesg.txt
     else
         echo "$(dmesg)" > /home/root/dmesg.txt
     fi

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -49,11 +49,6 @@ print_footer ()
 
 software_summary ()
 {
-    uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
-    uboot_env_vendor=$(fw_printenv vendor | sed -r "s/.*=//g")
-    uboot_env_vidargs=$(fw_printenv vidargs | sed -r "s/.*=//g")
-    uboot_env_sec_boot=$(fw_printenv sec_boot | sed -r "s/.*=//g")
-    uboot_env_bootdelay=$(fw_printenv bootdelay | sed -r "s/.*=//g")
     kernel_version=$(uname -rv)
     kernel_cmdline=$(cat /proc/cmdline)
     if [ -f /etc/os-release ]; then
@@ -66,11 +61,7 @@ software_summary ()
     hostname=$(cat /etc/hostname)
 
     print_header "Software summary"
-    print_info "U-Boot-version" "$uboot_version"
-    print_info "U-Boot vendor" "$uboot_env_vendor"
-    print_info "U-Boot video args" "$uboot_env_vidargs"
-    print_info "U-Boot secure boot" "$uboot_env_sec_boot"
-    print_info "U-Boot boot delay" "$uboot_env_bootdelay"
+    print_info "Bootloader" "$BOOTLOADER"
     print_info "Kernel version" "$kernel_version"
     print_info "Kernel command line" "$kernel_cmdline"
     print_info "Distro name" "$distro_name"
@@ -86,23 +77,54 @@ hardware_info ()
     som_pid8=$(tr -d '\0' </proc/device-tree/toradex,board-rev)
     serial=$(tr -d '\0' </proc/device-tree/serial-number)
     processor=$(uname -m)
-    uboot_env_board=$(fw_printenv board | sed -r "s/.*=//g")
-    uboot_env_fdt_board=$(fw_printenv fdt_board | sed -r "s/.*=//g")
-    uboot_env_soc=$(fw_printenv soc | sed -r "s/.*=//g")
 
     print_header "Hardware info"
     print_info "SoM model" "$som_model"
     print_info "SoM version" "$som_pid4 $som_pid8"
     print_info "SoM serial number" "$serial"
     print_info "Processor arch" "$processor"
-    print_info "U-Boot board" "$uboot_env_board"
-    print_info "U-Boot fdt_board" "$uboot_env_fdt_board"
-    print_info "U-Boot soc" "$uboot_env_soc"
     print_footer
 }
 
-device_tree_info()
+bootloader_info ()
 {
+    print_header "Bootloader info"
+    if [ "$BOOTLOADER" = "U-Boot" ]; then
+        uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
+        if [ "$(which fw_printenv)" ]; then
+            uboot_env_vendor=$(fw_printenv vendor | sed -r "s/.*=//g")
+            uboot_env_board=$(fw_printenv board | sed -r "s/.*=//g")
+            uboot_env_fdt_board=$(fw_printenv fdt_board | sed -r "s/.*=//g")
+            uboot_env_soc=$(fw_printenv soc | sed -r "s/.*=//g")
+            uboot_env_vidargs=$(fw_printenv vidargs | sed -r "s/.*=//g")
+            uboot_env_sec_boot=$(fw_printenv sec_boot | sed -r "s/.*=//g")
+            uboot_env_bootdelay=$(fw_printenv bootdelay | sed -r "s/.*=//g")
+        fi
+
+        print_info "U-Boot version" "$uboot_version"
+        print_info "U-Boot vendor" "$uboot_env_vendor"
+        print_info "U-Boot board" "$uboot_env_board"
+        print_info "U-Boot fdt_board" "$uboot_env_fdt_board"
+        print_info "U-Boot soc" "$uboot_env_soc"
+        print_info "U-Boot video args" "$uboot_env_vidargs"
+        print_info "U-Boot secure boot" "$uboot_env_sec_boot"
+        print_info "U-Boot boot delay" "$uboot_env_bootdelay"
+    elif [ "$BOOTLOADER" = "GRUB" ]; then
+        grub_version=$(grub-install --version | awk -F ' ' '{printf $NF}')
+
+        print_info "GRUB version" "$grub_version"
+    else
+        print_info "Unknown bootloader"
+    fi
+    print_footer
+}
+
+device_tree_info ()
+{
+    if [ ! "$USE_DEVICETREE" ]; then
+        return
+    fi
+
     dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
     dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
     if [ -d /boot/ostree ]; then
@@ -183,12 +205,23 @@ distro_detect ()
     fi
 }
 
+devicetree_detect ()
+{
+    # fw_utils are not present on L4T
+    # fw_utils presennce does not guarantee U-Boot is used
+    # GRUB seem to have some sort of support for device tree
+    if find /boot/ -name "*dtb" | grep -q . ; then
+        export USE_DEVICETREE=1
+    else
+        export USE_DEVICETREE=""
+    fi
+}
+
 bootloader_detect ()
 {
     if [ -f /boot/grub/grub.cfg ] || [ "$(command -v grub-install)" ]; then
         export BOOTLOADER="GRUB"
-    # fw_utils - thus fw_printenv - are not present on L4T
-    elif find /boot/ -name "*dtb" | grep -q . || [ "$(command -v fw_printenv)" ]; then
+    elif [ "$USE_DEVICETREE" ]; then
         export BOOTLOADER="U-Boot"
     # Don't care about other bootloaders for now, only GRUB and U-Boot
     else
@@ -201,6 +234,7 @@ help_info ()
     echo "Usage: tdx_version.sh [OPTION]"
     echo "List information about hardware and software from Toradex modules."
     echo ""
+    echo "--bootloader, -b   : Display bootloader related information (U-Boot and GRUB only)."
     echo "--devices, -d      : List all devices in /dev/."
     echo "--device-tree, -dt : Display device tree and overlays related information."
     echo "--dmesg, -dm       : Export the dmesg output in a txt file at ~."
@@ -215,6 +249,7 @@ help_info ()
 
 check_root_user
 distro_detect
+devicetree_detect
 bootloader_detect
 
 case $1 in
@@ -226,6 +261,9 @@ case $1 in
         ;;
     "--hardware" | "-w")
         hardware_info
+        ;;
+    "--bootloader" | "-b")
+        bootloader_info
         ;;
     "--device-tree" | "-dt")
         device_tree_info
@@ -246,6 +284,7 @@ case $1 in
     "-a" | "--all" | *)
         software_summary
         hardware_info
+        bootloader_info
         device_tree_info
         devices_info
         modules_info

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -47,7 +47,7 @@ print_footer ()
     printf "\n"
 }
 
-software_info ()
+software_summary ()
 {
     uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
     uboot_env_vendor=$(fw_printenv vendor | sed -r "s/.*=//g")
@@ -65,7 +65,7 @@ software_info ()
     fi
     hostname=$(cat /etc/hostname)
 
-    print_header "Software info"
+    print_header "Software summary"
     print_info "U-Boot-version" "$uboot_version"
     print_info "U-Boot vendor" "$uboot_env_vendor"
     print_info "U-Boot video args" "$uboot_env_vidargs"
@@ -222,7 +222,7 @@ case $1 in
         help_info 
         ;;
     "--software" | "-s")
-        software_info
+        software_summary
         ;;
     "--hardware" | "-w")
         hardware_info
@@ -234,7 +234,7 @@ case $1 in
         devices_info
         ;;
     "--no-devices" | "-nd")
-        software_info
+        software_summary
         hardware_info
         ;;
     "--dmesg" | "-dm")
@@ -244,7 +244,7 @@ case $1 in
         modules_info
         ;;
     "-a" | "--all" | *)
-        software_info
+        software_summary
         hardware_info
         device_tree_info
         devices_info

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -13,9 +13,9 @@ software_info ()
     uboot_env_bootdelay=$(fw_printenv bootdelay | sed -r "s/.*=//g")
     kernel_version=$(uname -rv)
     kernel_cmdline=$(cat /proc/cmdline)
-    if [[ -f /etc/os-release ]]; then
-        distro_name=$(cat /etc/os-release | grep ^NAME)
-        distro_version=$(cat /etc/os-release | grep VERSION_ID)
+    if [ -f /etc/os-release ]; then
+        distro_name=$(grep ^NAME /etc/os-release)
+        distro_version=$(grep VERSION_ID /etc/os-release)
     else
         distro_name=$(cat /etc/issue)
         distro_version=""
@@ -66,19 +66,21 @@ device_tree_info()
 {
     dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
     dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
-    if [[ -d /boot/ostree ]]; then
-        stateroot=$(cat /proc/cmdline | awk -F "ostree=" '{print $2}' | awk '{print $1}' | awk -F "/" '{print $5}')
-        dt_available=$(ls /boot/ostree/torizon-$stateroot/dtb/ | grep dtb)
-        if [[ -f /boot/ostree/torizon-$stateroot/dtb/overlays.txt ]]; then
-            dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
-            dto_available=$(ls /boot/ostree/torizon-$stateroot/dtb/overlays)
+    if [ -d /boot/ostree ]; then
+        stateroot=$(awk -F "ostree=" '{print $2}' /proc/cmdline | awk '{print $1}' | awk -F "/" '{print $5}')
+        # shellcheck disable=SC2010
+        dt_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/ | grep dtb)
+        if [ -f /boot/ostree/torizon-"$stateroot"/dtb/overlays.txt ]; then
+            dto_enabled=$(cat /boot/ostree/torizon-"$stateroot"/dtb/overlays.txt)
+            dto_available=$(ls /boot/ostree/torizon-"$stateroot"/dtb/overlays)
         else
             dto_enabled=""
             dto_available=""
         fi
     else
+        # shellcheck disable=SC2010
         dt_available=$(ls /boot/ | grep dtb)
-        if [[ -f /boot/overlays.txt ]]; then
+        if [ -f /boot/overlays.txt ]; then
             dto_enabled=$(cat /boot/overlays.txt)
             dto_available=$(ls /boot/overlays)
         else
@@ -128,17 +130,17 @@ modules_info ()
 dmesg_log ()
 {
     loggeduser=${SUDO_USER:-$(logname)}
-    echo "$(dmesg)" > /home/$loggeduser/dmesg.txt
-    chown $loggeduser:$loggeduser /home/$loggeduser/dmesg.txt
+    dmesg > /home/"$loggeduser"/dmesg.txt
+    chown "$loggeduser":"$loggeduser" /home/"$loggeduser"/dmesg.txt
 }
 
 distro_detect ()
 {
     # For (arguably) any modern distro, rely on /etc/os-release
-    if [[ -f /etc/os-release ]]; then
-        export "DISTRO_$(cat /etc/os-release | grep ^NAME)"
+    if [ -f /etc/os-release ]; then
+        export "DISTRO_$(grep ^NAME /etc/os-release)"
     else
-        DISTRO_NAME="Unknown"
+        export DISTRO_NAME="Unknown"
     fi
 }
 

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -5,16 +5,16 @@
 # Author: hiagofranco & g-claudino
 
 if [ "$(id -u)" != "0" ]; then
-	echo "Please, run as root."
-	exit
+    echo "Please, run as root."
+    exit
 fi
 
 distro_name=$(uname -a)
 ref_name="Torizon"
 if [[ $distro_name =~ $ref_name ]]; then
-	ref_distro=$ref_name
+    ref_distro=$ref_name
 else
-	ref_distro="BSP"
+    ref_distro="BSP"
 fi
 
 software_info ()
@@ -140,9 +140,9 @@ help_info ()
 dmesg_log ()
 {
     if [[ $ref_distro =~ $ref_name ]]; then
-	    echo "$(dmesg)" > /home/torizon/dmesg.txt
+        echo "$(dmesg)" > /home/torizon/dmesg.txt
     else
-	    echo "$(dmesg)" > /home/root/dmesg.txt
+        echo "$(dmesg)" > /home/root/dmesg.txt
     fi
 }
 
@@ -177,8 +177,8 @@ case $1 in
         overlays_info
         ;;
     "--dmesg" | "-dm")
-      	dmesg_log
-	      ;;
+        dmesg_log
+          ;;
     "--modules" | "-m")
         modules_info
         ;;
@@ -186,7 +186,7 @@ case $1 in
         software_info
         hardware_info
         devices_info
-	overlays_info
+        overlays_info
         modules_info
         ;;
 esac

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -66,7 +66,7 @@ device_tree_info()
 {
     dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
     dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
-    if [[ $ref_distro =~ $ref_name ]]; then
+    if [[ -d /boot/ostree ]]; then
         stateroot=$(cat /proc/cmdline | awk -F "ostree=" '{print $2}' | awk '{print $1}' | awk -F "/" '{print $5}')
         dt_available=$(ls /boot/ostree/torizon-$stateroot/dtb/ | grep dtb)
         dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
@@ -148,9 +148,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 distro_name=$(uname -a)
-ref_name="Torizon"
-if [[ $distro_name =~ $ref_name ]]; then
-    ref_distro=$ref_name
+if [[ $distro_name =~ "Torizon" ]]; then
+    ref_distro="Torizon"
 else
     ref_distro="BSP"
 fi

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -4,19 +4,6 @@
 # Date: may-02-2022
 # Author: hiagofranco & g-claudino
 
-if [ "$(id -u)" != "0" ]; then
-    echo "Please, run as root."
-    exit
-fi
-
-distro_name=$(uname -a)
-ref_name="Torizon"
-if [[ $distro_name =~ $ref_name ]]; then
-    ref_distro=$ref_name
-else
-    ref_distro="BSP"
-fi
-
 software_info ()
 {
     uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
@@ -152,6 +139,21 @@ help_info ()
     echo "--software, -s     : Display only software information."
     echo ""
 }
+
+# Main
+
+if [ "$(id -u)" != "0" ]; then
+    echo "Please, run as root."
+    exit
+fi
+
+distro_name=$(uname -a)
+ref_name="Torizon"
+if [[ $distro_name =~ $ref_name ]]; then
+    ref_distro=$ref_name
+else
+    ref_distro="BSP"
+fi
 
 case $1 in
     "--help" | "-h")

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -122,6 +122,16 @@ dmesg_log ()
     chown $loggeduser:$loggeduser /home/$loggeduser/dmesg.txt
 }
 
+distro_detect ()
+{
+    # For (arguably) any modern distro, rely on /etc/os-release
+    if [[ -f /etc/os-release ]]; then
+        export "DISTRO_$(cat /etc/os-release | grep ^NAME)"
+    else
+        DISTRO_NAME="BSP"
+    fi
+}
+
 help_info ()
 {
     echo "Usage: tdx_version.sh [OPTION]"
@@ -144,12 +154,7 @@ if [ "$(id -u)" != "0" ]; then
     exit
 fi
 
-distro_name=$(uname -a)
-if [[ $distro_name =~ "Torizon" ]]; then
-    ref_distro="Torizon"
-else
-    ref_distro="BSP"
-fi
+distro_detect
 
 case $1 in
     "--help" | "-h")

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -165,6 +165,14 @@ dmesg_log ()
     chown "$loggeduser":"$loggeduser" /home/"$loggeduser"/dmesg.txt
 }
 
+check_root_user ()
+{
+    if [ "$(id -u)" != "0" ]; then
+        echo "Please, run as root."
+        exit 13
+    fi
+}
+
 distro_detect ()
 {
     # For (arguably) any modern distro, rely on /etc/os-release
@@ -192,11 +200,7 @@ help_info ()
 
 #### Main ####
 
-if [ "$(id -u)" != "0" ]; then
-    echo "Please, run as root."
-    exit
-fi
-
+check_root_user
 distro_detect
 
 case $1 in

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -71,22 +71,34 @@ hardware_info ()
     echo "-----------------"
 }
 
-overlays_info()
+device_tree_info()
 {
+    dt_compatible=$(tr -d '\0' </proc/device-tree/compatible)
+    dt_used=$(fw_printenv fdtfile | sed -r "s/.*=//g")
     if [[ $ref_distro =~ $ref_name ]]; then
         stateroot=$(cat /proc/cmdline | awk -F "ostree=" '{print $2}' | awk '{print $1}' | awk -F "/" '{print $5}')
+        dt_available=$(ls /boot/ostree/torizon-$stateroot/dtb/ | grep dtb)
         dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
         dto_available=$(ls /boot/ostree/torizon-$stateroot/dtb/overlays)
     else
+        dt_available=$(ls /boot/ | grep dtb)
         dto_enabled=$(cat /boot/overlays.txt)
         dto_available=$(ls /boot/overlays)
     fi
 
     echo ""
-    echo "Device Tree Overlays"
+    echo "Device tree"
     echo "-----------------"
-    echo "Device tree overlays enabled:[$dto_enabled]"
-    echo "Device tree overlays available:[$dto_available]"
+    echo "Device tree enabled:[$dt_used]"
+    echo "Compatible string:[$dt_compatible]"
+    echo "Device trees available:[$dt_available]"
+    echo "-----------------"
+
+    echo ""
+    echo "-----------------"
+    echo "Device tree overlays"
+    echo "Overlays enabled:[$dto_enabled]"
+    echo "Overlays available:[$dto_available]"
     echo "-----------------"
 }
 
@@ -127,13 +139,13 @@ help_info ()
     echo "Usage: tdx_version.sh [OPTION]"
     echo "List information about hardware and software from Toradex modules."
     echo ""
-    echo "--devices, -d     : List all devices in /dev/."
-    echo "--dmesg, -dm      : Export the dmesg output in a txt file at ~."
-    echo "--help, -h        : Display this message."
-    echo "--no-devices, -nd : Diplay hardware and software information without listing devices."
-    echo "--overlays, -o    : Display overlay related information."
-    echo "--software, -s    : Display only software information."
-    echo "--hardware, -w    : Display only hardware information."
+    echo "--devices, -d      : List all devices in /dev/."
+    echo "--device-tree, -dt : Display device tree and overlays related information."
+    echo "--dmesg, -dm       : Export the dmesg output in a txt file at ~."
+    echo "--hardware, -w     : Display only hardware information."
+    echo "--help, -h         : Display this message."
+    echo "--no-devices, -nd  : Diplay hardware and software information without listing devices."
+    echo "--software, -s     : Display only software information."
     echo ""
 }
 
@@ -147,15 +159,15 @@ case $1 in
     "--hardware" | "-w")
         hardware_info
         ;;
+    "--device-tree" | "-dt")
+        device_tree_info
+        ;;
     "--devices" | "-d")
         devices_info
         ;;
     "--no-devices" | "-nd")
         software_info
         hardware_info
-        ;;
-    "--overlays" | "-o")
-        overlays_info
         ;;
     "--dmesg" | "-dm")
         dmesg_log
@@ -166,7 +178,7 @@ case $1 in
     "-a" | "--all" | *)
         software_info
         hardware_info
-        overlays_info
+        device_tree_info
         devices_info
         modules_info
         ;;

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -4,12 +4,12 @@
 # Date: may-02-2022
 # Author: hiagofranco & g-claudino
 
-if [ "`id -u`" != "0" ]; then
+if [ "$(id -u)" != "0" ]; then
 	echo "Please, run as root."
 	exit
 fi
 
-distro_name="`uname -a`"
+distro_name=$(uname -a)
 ref_name="Torizon"
 if [[ $distro_name =~ $ref_name ]]; then
 	ref_distro=$ref_name
@@ -22,23 +22,23 @@ software_info ()
     echo ""
     echo "Software info:"
     echo "-----------------"
-    echo "uname-all:[`uname -a`]"
-    echo "kernel:[`uname -r`]"
-    echo "kernel-version:[`uname -r | sed -r "s/\+.*//g" | sed -r "s/-.*//g" `]"
-    echo "kernel-release:[`uname -v`]"
-    echo "BSP-version:[`uname -r | sed -r "s/.*-//g" | sed -r "s/\+.*//g" `]"
+    echo "uname-all:[$(uname -a)]"
+    echo "kernel:[$(uname -r)]"
+    echo "kernel-version:[$(uname -r | sed -r "s/\+.*//g" | sed -r "s/-.*//g" )]"
+    echo "kernel-release:[$(uname -v)]"
+    echo "BSP-version:[$(uname -r | sed -r "s/.*-//g" | sed -r "s/\+.*//g" )]"
     echo "-----------------"
     echo "/etc/os-release:"
-    echo "`cat /etc/os-release`"
+    echo "$(cat /etc/os-release)"
     echo "-----------------"
     echo "/etc/issue:"
-    echo "`cat /etc/issue`"
+    echo "$(cat /etc/issue)"
     echo "-----------------"
-    echo "U-Boot-version:[`tr -d '\0' </proc/device-tree/chosen/u-boot,version`]"
-    echo "vendor:[`fw_printenv vendor | sed -r "s/.*=//g"`]"
-    echo "video args:[`fw_printenv vidargs | sed -r "s/.*=//g"`]"
-    echo "secure boot:[`fw_printenv sec_boot | sed -r "s/.*=//g"`]"
-    echo "boot delay:[`fw_printenv bootdelay | sed -r "s/.*=//g"`]"
+    echo "U-Boot-version:[$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)]"
+    echo "vendor:[$(fw_printenv vendor | sed -r "s/.*=//g")]"
+    echo "video args:[$(fw_printenv vidargs | sed -r "s/.*=//g")]"
+    echo "secure boot:[$(fw_printenv sec_boot | sed -r "s/.*=//g")]"
+    echo "boot delay:[$(fw_printenv bootdelay | sed -r "s/.*=//g")]"
     echo "-----------------"
 }
 
@@ -47,17 +47,17 @@ hardware_info ()
     echo ""
     echo "Hardware info:"
     echo "-----------------"
-    echo "processor:[`uname -m`]"
+    echo "processor:[$(uname -m)]"
     if [[ $ref_distro =~ $ref_name ]]; then
-    	echo "device-tree-overlays:[`cat /boot/ostree/torizon*/dtb/overlays.txt`]"
+        echo "device-tree-overlays:[$(cat /boot/ostree/torizon*/dtb/overlays.txt)]"
     else
-	echo "device-tree-overlays:[`cat /boot/overlays.txt`]"
+        echo "device-tree-overlays:[$(cat /boot/overlays.txt)]"
     fi
-    echo "board:[`fw_printenv board | sed -r "s/.*=//g"`]"
-    echo "fdt_board:[`fw_printenv fdt_board | sed -r "s/.*=//g"`]"
-    echo "soc:[`fw_printenv soc | sed -r "s/.*=//g"`]"
-    echo "SoM model:[`tr -d '\0' </proc/device-tree/model`]"
-    echo "SoM version:[`tr -d '\0' </proc/device-tree/toradex,product-id` `tr -d '\0' </proc/device-tree/toradex,board-rev`]"
+    echo "board:[$(fw_printenv board | sed -r "s/.*=//g")]"
+    echo "fdt_board:[$(fw_printenv fdt_board | sed -r "s/.*=//g")]"
+    echo "soc:[$(fw_printenv soc | sed -r "s/.*=//g")]"
+    echo "SoM model:[$(tr -d '\0' </proc/device-tree/model)]"
+    echo "SoM version:[$(tr -d '\0' </proc/device-tree/toradex,product-id) $(tr -d '\0' </proc/device-tree/toradex,board-rev)]"
     echo "-----------------"
 }
 
@@ -66,7 +66,7 @@ devices_info ()
     echo ""
     echo "All devices:"
     echo "-----------------"
-    echo "`ls -lh /dev`"
+    echo "$(ls -lh /dev)"
     echo "-----------------"
     echo "END"
 }
@@ -75,9 +75,9 @@ overlays_info(){
     echo "Overlays Available:"
     echo "-----------------"
     if [[ $ref_distro =~ $ref_name ]]; then
-        echo "`ls -lh /boot/ostree/torizon*/dtb/overlays`"
+        echo "$(ls -lh /boot/ostree/torizon*/dtb/overlays)"
     else
-        echo "`ls -lh /boot/overlays`"
+        echo "$(ls -lh /boot/overlays)"
     fi
     echo "-----------------"
 }
@@ -86,9 +86,9 @@ overlays_enabled(){
     echo "Overlays Enabled:"
     echo "-----------------"
     if [[ $ref_distro =~ $ref_name ]]; then
-        echo "device-tree-overlays:[`cat /boot/ostree/torizon*/dtb/overlays.txt`]"
+        echo "device-tree-overlays:[$(cat /boot/ostree/torizon*/dtb/overlays.txt)]"
     else
-        echo "device-tree-overlays:[`cat /boot/overlays.txt`]"
+        echo "device-tree-overlays:[$(cat /boot/overlays.txt)]"
     fi
     echo "-----------------"
 }
@@ -112,16 +112,16 @@ help_info ()
 dmesg_log ()
 {
     if [[ $ref_distro =~ $ref_name ]]; then
-	    echo "`dmesg`" > /home/torizon/dmesg.txt
+	    echo "$(dmesg)" > /home/torizon/dmesg.txt
     else
-	    echo "`dmesg`" > /home/root/dmesg.txt
+	    echo "$(dmesg)" > /home/root/dmesg.txt
     fi
 }
 
 modules_info (){
     echo "Current list of kernel modules"
     echo "-----------------"
-    echo "`lsmod`"
+    echo "$(lsmod)"
     echo "-----------------"
 }
 

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -35,7 +35,7 @@ software_info ()
     fi
 
     echo ""
-    echo "Software info:"
+    echo "Software info"
     echo "-----------------"
     echo "U-Boot-version:[$uboot_version]"
     echo "U-Boot vendor:[$uboot_env_vendor]"
@@ -60,7 +60,7 @@ hardware_info ()
     uboot_env_soc=$(fw_printenv soc | sed -r "s/.*=//g")
 
     echo ""
-    echo "Hardware info:"
+    echo "Hardware info"
     echo "-----------------"
     echo "SoM model:[$som_model]"
     echo "SoM version:[$som_pid4 $som_pid8]"
@@ -71,7 +71,8 @@ hardware_info ()
     echo "-----------------"
 }
 
-overlays_info(){
+overlays_info()
+{
     if [[ $ref_distro =~ $ref_name ]]; then
         stateroot=$(cat /proc/cmdline | awk -F "ostree=" '{print $2}' | awk '{print $1}' | awk -F "/" '{print $5}')
         dto_enabled=$(cat /boot/ostree/torizon-$stateroot/dtb/overlays.txt)
@@ -82,7 +83,7 @@ overlays_info(){
     fi
 
     echo ""
-    echo "Device Tree Overlays:"
+    echo "Device Tree Overlays"
     echo "-----------------"
     echo "Device tree overlays enabled:[$dto_enabled]"
     echo "Device tree overlays available:[$dto_available]"
@@ -94,11 +95,30 @@ devices_info ()
     devices=$(ls -lh /dev)
 
     echo ""
-    echo "All devices:"
+    echo "Devices"
     echo "-----------------"
-    echo "$devices"
+    echo "All devices available:[$devices]"
     echo "-----------------"
-    echo "END"
+}
+
+modules_info ()
+{
+    lsmod=$(lsmod)
+
+    echo ""
+    echo "Kernel modules"
+    echo "-----------------"
+    echo "Kernel modules loaded:[$lsmod]"
+    echo "-----------------"
+}
+
+dmesg_log ()
+{
+    if [[ $ref_distro =~ $ref_name ]]; then
+        echo "$(dmesg)" > /home/torizon/dmesg.txt
+    else
+        echo "$(dmesg)" > /home/root/dmesg.txt
+    fi
 }
 
 help_info ()
@@ -114,25 +134,6 @@ help_info ()
     echo "--software, -s    : Display only software information."
     echo "--hardware, -w    : Display only hardware information."
     echo ""
-}
-
-
-dmesg_log ()
-{
-    if [[ $ref_distro =~ $ref_name ]]; then
-        echo "$(dmesg)" > /home/torizon/dmesg.txt
-    else
-        echo "$(dmesg)" > /home/root/dmesg.txt
-    fi
-}
-
-modules_info (){
-    lsmod=$(lsmod)
-
-    echo "Current list of kernel modules"
-    echo "-----------------"
-    echo "$lsmod"
-    echo "-----------------"
 }
 
 case $1 in

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -117,12 +117,9 @@ modules_info ()
 
 dmesg_log ()
 {
-    if [[ $ref_distro =~ $ref_name ]]; then
-        echo "$(dmesg)" > /home/torizon/dmesg.txt
-        chown torizon:torizon /home/torizon/dmesg.txt
-    else
-        echo "$(dmesg)" > /home/root/dmesg.txt
-    fi
+    loggeduser=${SUDO_USER:-$(logname)}
+    echo "$(dmesg)" > /home/$loggeduser/dmesg.txt
+    chown $loggeduser:$loggeduser /home/$loggeduser/dmesg.txt
 }
 
 help_info ()

--- a/tdx_version.sh
+++ b/tdx_version.sh
@@ -19,39 +19,33 @@ fi
 
 software_info ()
 {
-    uname=$(uname -a)
-    kernel=$(uname -r)
-    kernel_version=$(echo $kernel | sed -r "s/\+.*//g" | sed -r "s/-.*//g")
-    kernel_release=$(uname -v)
-    bsp_version=$(echo $kernel | sed -r "s/.*-//g" | sed -r "s/\+.*//g")
-    os_release=$(cat /etc/os-release)
-    etc_issue=$(cat /etc/issue)
     uboot_version=$(tr -d '\0' </proc/device-tree/chosen/u-boot,version)
     uboot_env_vendor=$(fw_printenv vendor | sed -r "s/.*=//g")
     uboot_env_vidargs=$(fw_printenv vidargs | sed -r "s/.*=//g")
     uboot_env_sec_boot=$(fw_printenv sec_boot | sed -r "s/.*=//g")
     uboot_env_bootdelay=$(fw_printenv bootdelay | sed -r "s/.*=//g")
+    kernel_version=$(uname -rv)
+    kernel_cmdline=$(cat /proc/cmdline)
+    if [[ -f /etc/os-release ]]; then
+        distro_name=$(cat /etc/os-release | grep ^NAME)
+        distro_version=$(cat /etc/os-release | grep VERSION_ID)
+    else
+        distro_name=$(cat /etc/issue)
+        distro_version=""
+    fi
 
     echo ""
     echo "Software info:"
     echo "-----------------"
-    echo "uname-all:[$uname]"
-    echo "kernel:[$kernel]"
-    echo "kernel-version:[$kernel_version]"
-    echo "kernel-release:[$kernel_release]"
-    echo "BSP-version:[$bsp_version]"
-    echo "-----------------"
-    echo "/etc/os-release:"
-    echo "$os_release"
-    echo "-----------------"
-    echo "/etc/issue:"
-    echo "$etc_issue"
-    echo "-----------------"
     echo "U-Boot-version:[$uboot_version]"
-    echo "vendor:[$uboot_env_vendor]"
-    echo "video args:[$uboot_env_vidargs]"
-    echo "secure boot:[$uboot_env_sec_boot]"
-    echo "boot delay:[$uboot_env_bootdelay]"
+    echo "U-Boot vendor:[$uboot_env_vendor]"
+    echo "U-Boot video args:[$uboot_env_vidargs]"
+    echo "U-Boot secure boot:[$uboot_env_sec_boot]"
+    echo "U-Boot boot delay:[$uboot_env_bootdelay]"
+    echo "Kernel version:[$kernel_version]"
+    echo "Kernel command line:[$kernel_cmdline]"
+    echo "Distro name:[$distro_name]"
+    echo "Distro version:[$distro_version]"
     echo "-----------------"
 }
 


### PR DESCRIPTION
This PR contains a misc of contributions. Below is a summary, the reasons for each of them are described in their respective commits:

- Use `$(...)` instead of `` `...` ``
- Inside a function, first, fetch all data, then print all data
- Consistently use 4 spaces for code tabulation
- Remove duplicated data to keep logs concise
- Standardize print style and use print functions for formatting
- Fetch and print some additional data, such as hostname and serial
- Use the ShellCheck linter to improve code quality
- Generalize some code to allow the script to run on other hardware and architecture
- Unify bootloader data in a separate section